### PR TITLE
Enable extended mode for Twitter4j

### DIFF
--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/twitter4j/Twitter4JComponents.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/twitter4j/Twitter4JComponents.java
@@ -24,6 +24,7 @@ public class Twitter4JComponents {
         final String consumerSecret = environment.getProperty("twitter.consumerSecret");
         cb.setOAuthConsumerSecret(consumerSecret);
         cb.setOAuthConsumerKey(consumerKey);
+        cb.setTweetModeExtended(true);
         return cb.build();
     }
 


### PR DESCRIPTION
Fixes #8 so that 140+ characters tweets' text are not truncated with an ellipsis.
Does not apply to quoted tweets. They will require more specific tuning.