### PR TITLE
Set inReplyTo field for tweet replies

### DIFF
--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/services/NewTweetService.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/services/NewTweetService.java
@@ -57,6 +57,14 @@ public class NewTweetService {
         this.sessionManager = sessionManager;
     }
 
+    /**
+     * Asynchronously sends a normal tweet.
+     *
+     * @param content The content of the tweet
+     * @param medias  The attachments to upload and link in the tweet
+     *
+     * @return A {@link CompletionStage} to follow the status of the asynchronous request
+     */
     public CompletionStage<Status> sendTweet(final String content, final List<File> medias) {
         return prepateNewTweet(content, medias).thenApplyAsync(
                 update -> sessionManager.doWithCurrentTwitter(twitter -> twitter.updateStatus(update)).get(),
@@ -64,6 +72,15 @@ public class NewTweetService {
         );
     }
 
+    /**
+     * Asynchronously sends a reply to a tweet.
+     *
+     * @param content   The content of the reply
+     * @param medias    The attachments to upload and link in the reply
+     * @param inReplyTo The tweet that this is in reply to
+     *
+     * @return A {@link CompletionStage} to follow the status of the asynchronous request
+     */
     public CompletionStage<Status> sendReply(final String content, final List<File> medias, final long inReplyTo) {
         return prepateNewTweet(content, medias).thenApplyAsync(
                 update -> {

--- a/lyrebird/src/main/java/moe/lyrebird/view/screens/newtweet/NewTweetController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/screens/newtweet/NewTweetController.java
@@ -218,6 +218,10 @@ public class NewTweetController implements FxmlController, StageAware {
         });
     }
 
+    /**
+     * Dynamically either sends a normal tweet or a reply depending on whether the controller was used to prepare a
+     * "normal" new tweet or a reply (i.e. if there was a value set for {@link #inReplyStatus}.
+     */
     private void send() {
         if (inReplyStatus.getValue() == null) {
             sendTweet();


### PR DESCRIPTION
# Set inReplyTo field for tweet replies
### Fixes #87 

#### Summary
Formerly, "replies" only had the content expected of a reply but did not specify which tweet they were in reply to which meant Twitter did not consider them as replies but rather as standard new mentions/conversations.

#### Potential issues
A few assumptions about the lifecycle of `NewTweetController#inReplyToStatus`

#### Checks:
- [x] Documented code
- [x] Based on `develop` branch
