### PR TITLE
Fix systray on linux

### DIFF
--- a/lyrebird/pom.xml
+++ b/lyrebird/pom.xml
@@ -223,6 +223,12 @@
             <artifactId>prettytime</artifactId>
             <version>4.0.1.Final</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.dorkbox</groupId>
+            <artifactId>SystemTray</artifactId>
+            <version>3.14</version>
+        </dependency>
     </dependencies>
 
     <pluginRepositories>

--- a/lyrebird/src/main/java/moe/lyrebird/Lyrebird.java
+++ b/lyrebird/src/main/java/moe/lyrebird/Lyrebird.java
@@ -18,21 +18,22 @@
 
 package moe.lyrebird;
 
+import java.awt.Toolkit;
+
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Import;
-import moe.tristan.easyfxml.spring.application.FxSpringApplication;
-import moe.tristan.easyfxml.spring.application.FxSpringContext;
-import moe.tristan.easyfxml.spring.application.FxUiManager;
+
+import dorkbox.util.OS;
+import javafx.application.Application;
+import javafx.stage.Stage;
 import moe.lyrebird.api.client.LyrebirdServerClientConfiguration;
 import moe.lyrebird.model.interrupts.CleanupService;
 import moe.lyrebird.model.update.compatibility.PostUpdateCompatibilityHelper;
 import moe.lyrebird.view.LyrebirdUiManager;
-
-import javafx.application.Application;
-import javafx.stage.Stage;
-
-import java.awt.Toolkit;
+import moe.tristan.easyfxml.spring.application.FxSpringApplication;
+import moe.tristan.easyfxml.spring.application.FxSpringContext;
+import moe.tristan.easyfxml.spring.application.FxUiManager;
 
 /**
  * This class is the entry point for Lyrebird. It bootstraps JavaFX, Spring Boot and AWT and then delegates
@@ -65,6 +66,9 @@ public class Lyrebird extends FxSpringApplication {
      */
     public static void main(final String[] args) {
         PostUpdateCompatibilityHelper.getInstance().executeCompatibilityTasks();
+        if (OS.isMacOsX()) {
+            System.setProperty("javafx.macosx.embedded", "true");
+        }
         Toolkit.getDefaultToolkit();
         launch(args);
     }

--- a/lyrebird/src/main/java/moe/lyrebird/model/systemtray/LyrebirdTrayIcon.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/systemtray/LyrebirdTrayIcon.java
@@ -1,26 +1,23 @@
 package moe.lyrebird.model.systemtray;
 
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Component;
-import moe.tristan.easyfxml.model.awt.integrations.SystemTrayIcon;
-import moe.tristan.easyfxml.model.awt.objects.OnMouseClickListener;
-import moe.tristan.easyfxml.model.beanmanagement.StageManager;
-import moe.lyrebird.view.screens.Screen;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javafx.application.Platform;
-import javafx.stage.Stage;
-
-import java.awt.MenuItem;
+import java.awt.*;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import javafx.application.Platform;
+import moe.lyrebird.view.screens.Screen;
+import moe.tristan.easyfxml.model.awt.integrations.SystemTrayIcon;
+import moe.tristan.easyfxml.model.beanmanagement.StageManager;
 
 /**
  * The {@link SystemTrayIcon} that is registered in the current OS's tray bar.
@@ -62,19 +59,8 @@ public class LyrebirdTrayIcon implements SystemTrayIcon {
 
     @Override
     public MouseListener onMouseClickListener() {
-        return new OnMouseClickListener(this::handleTrayClick);
-    }
-
-    private void handleTrayClick(final MouseEvent mouseEvent) {
-        final Stage mainStage = stageManager.getSingle(Screen.ROOT_VIEW).get();
-        LOG.debug("Registered a click on the tray icon!");
-        if (mainStage.isShowing() && !mainStage.isIconified()) {
-            LOG.debug("Main stage already showing. Do not re-force front focus.");
-        }
-        if (mouseEvent.getButton() == MouseEvent.BUTTON1) {
-            LOG.debug("Requested display of main stage!");
-            this.showMainStage();
-        }
+        //noop
+        return null;
     }
 
     /**

--- a/lyrebird/src/main/java/moe/lyrebird/model/systemtray/SystemTrayService.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/systemtray/SystemTrayService.java
@@ -19,9 +19,6 @@
 package moe.lyrebird.model.systemtray;
 
 import java.awt.*;
-import java.util.concurrent.CompletableFuture;
-
-import javax.swing.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,26 +62,24 @@ public class SystemTrayService {
     private void loadTrayIcon() {
         LOG.debug("Registering tray icon for Lyrebird...");
         if (OS.isLinux()) {
-            SystemTray.FORCE_TRAY_TYPE= SystemTray.TrayType.GtkStatusIcon;
+            SystemTray.FORCE_TRAY_TYPE = SystemTray.TrayType.Swing;
         }
 
-        CompletableFuture.supplyAsync(() -> {
-            LOG.debug("Creating a tray icon...");
-            SystemTray tray = SystemTray.get();
-            tray.setImage(lyrebirdTrayIcon.getIcon());
-            tray.setTooltip("Lyrebird");
-            return tray;
-        }).thenApplyAsync(tray -> {
-            LOG.debug("Adding items to tray icon's menu...");
-            final JMenu menu = new JMenu();
-            lyrebirdTrayIcon.getMenuItems().forEach((item, action) -> {
-                final JMenuItem menuItem = new JMenuItem(item.getLabel());
-                menuItem.addActionListener(action);
-                menu.add(menuItem);
-            });
-            tray.setMenu(menu);
-            return tray;
-        }).thenRunAsync(() -> LOG.debug("Finished creating tray icon!"));
+        LOG.debug("Creating a tray icon...");
+        SystemTray tray = SystemTray.get();
+        tray.setImage(lyrebirdTrayIcon.getIcon());
+        tray.setTooltip("Lyrebird");
+
+        LOG.debug("Adding items to tray icon's menu...");
+        //final JMenu menu = new JMenu();
+        //lyrebirdTrayIcon.getMenuItems().forEach((item, action) -> {
+        //    final JMenuItem menuItem = new JMenuItem(item.getLabel());
+        //    menuItem.addActionListener(action);
+        //    menu.add(menuItem);
+        //});
+        //tray.setMenu(menu);
+
+        LOG.debug("Finished creating tray icon!");
     }
 
 }

--- a/lyrebird/src/main/java/moe/lyrebird/model/systemtray/SystemTrayService.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/systemtray/SystemTrayService.java
@@ -24,11 +24,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import dorkbox.systemTray.Menu;
+import dorkbox.systemTray.MenuItem;
 import dorkbox.systemTray.SystemTray;
 import dorkbox.util.OS;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleObjectProperty;
-import moe.lyrebird.model.interrupts.CleanupService;
 
 /**
  * This class is responsible for management and exposure of the {@link LyrebirdTrayIcon}.
@@ -39,16 +40,11 @@ public class SystemTrayService {
     private static final Logger LOG = LoggerFactory.getLogger(SystemTrayService.class);
 
     private final LyrebirdTrayIcon lyrebirdTrayIcon;
-    private final CleanupService cleanupService;
 
     private final Property<TrayIcon> trayIcon = new SimpleObjectProperty<>(null);
 
-    public SystemTrayService(
-            final LyrebirdTrayIcon lyrebirdTrayIcon,
-            final CleanupService cleanupService
-    ) {
+    public SystemTrayService(final LyrebirdTrayIcon lyrebirdTrayIcon) {
         this.lyrebirdTrayIcon = lyrebirdTrayIcon;
-        this.cleanupService = cleanupService;
         loadTrayIcon();
     }
 
@@ -62,7 +58,7 @@ public class SystemTrayService {
     private void loadTrayIcon() {
         LOG.debug("Registering tray icon for Lyrebird...");
         if (OS.isLinux()) {
-            SystemTray.FORCE_TRAY_TYPE = SystemTray.TrayType.Swing;
+            SystemTray.FORCE_TRAY_TYPE = SystemTray.TrayType.GtkStatusIcon;
         }
 
         LOG.debug("Creating a tray icon...");
@@ -71,13 +67,14 @@ public class SystemTrayService {
         tray.setTooltip("Lyrebird");
 
         LOG.debug("Adding items to tray icon's menu...");
-        //final JMenu menu = new JMenu();
-        //lyrebirdTrayIcon.getMenuItems().forEach((item, action) -> {
-        //    final JMenuItem menuItem = new JMenuItem(item.getLabel());
-        //    menuItem.addActionListener(action);
-        //    menu.add(menuItem);
-        //});
-        //tray.setMenu(menu);
+        final Menu menu = tray.getMenu();
+
+        lyrebirdTrayIcon.getMenuItems().forEach((item, action) -> {
+            LOG.debug("Adding menu item : {} (callback : {})", item, action);
+            final MenuItem menuItem = new MenuItem(item.getLabel());
+            menuItem.setCallback(action);
+            menu.add(menuItem);
+        });
 
         LOG.debug("Finished creating tray icon!");
     }

--- a/lyrebird/src/main/resources/application.properties
+++ b/lyrebird/src/main/resources/application.properties
@@ -20,6 +20,7 @@
 logging.level.root=WARN
 logging.level.moe.lyrebird=DEBUG
 logging.level.moe.tristan=INFO
+logging.level.dorkbox=TRACE
 logging.file=${user.home}/.lyrebird/lyrebird.log
 logging.file.max-size=2MB
 logging.file.max-history=5


### PR DESCRIPTION
# Fix system tray issues on Linux
### Fixes #99 (partially)

#### Summary
Switch to Dorkbox for System tray implementation.

#### Potential issues
Recent Gnome versions break it up. You will need topicon gnome shell extensions on these ones.
ElementaryOS thinks system tray is bad. Can't do anything for people that oblivious.

#### Checks:
- [x] Documented code
- [x] Based on `develop` branch
