### PR TITLE
Clickable content urls

### DIFF
--- a/lyrebird/pom.xml
+++ b/lyrebird/pom.xml
@@ -177,11 +177,6 @@
             <version>2.1.17</version>
         </dependency>
         <dependency>
-            <groupId>org.controlsfx</groupId>
-            <artifactId>controlsfx</artifactId>
-            <version>9.0.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.dorkbox</groupId>
             <artifactId>SystemTray</artifactId>
             <version>3.14</version>

--- a/lyrebird/pom.xml
+++ b/lyrebird/pom.xml
@@ -102,6 +102,12 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>moe.lyrebird</groupId>
+            <artifactId>lyrebird-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Spring Boot -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -125,7 +131,6 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
-
         <!-- DB (H2) -->
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -172,6 +177,16 @@
             <version>2.1.17</version>
         </dependency>
         <dependency>
+            <groupId>org.controlsfx</groupId>
+            <artifactId>controlsfx</artifactId>
+            <version>9.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.dorkbox</groupId>
+            <artifactId>SystemTray</artifactId>
+            <version>3.14</version>
+        </dependency>
+        <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-core</artifactId>
             <version>4.0.13-alpha</version>
@@ -190,26 +205,16 @@
             <artifactId>jaxb-api</artifactId>
         </dependency>
 
+        <!-- Misc -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>25.1-jre</version>
         </dependency>
         <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <version>3.1.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-all</artifactId>
             <version>0.34.6</version>
-        </dependency>
-
-        <dependency>
-            <groupId>moe.lyrebird</groupId>
-            <artifactId>lyrebird-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -222,12 +227,6 @@
             <groupId>org.ocpsoft.prettytime</groupId>
             <artifactId>prettytime</artifactId>
             <version>4.0.1.Final</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.dorkbox</groupId>
-            <artifactId>SystemTray</artifactId>
-            <version>3.14</version>
         </dependency>
     </dependencies>
 

--- a/lyrebird/src/main/java/moe/lyrebird/view/LyrebirdUiManager.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/LyrebirdUiManager.java
@@ -18,26 +18,26 @@
 
 package moe.lyrebird.view;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
-import moe.tristan.easyfxml.EasyFxml;
-import moe.tristan.easyfxml.api.FxmlNode;
-import moe.tristan.easyfxml.model.beanmanagement.StageManager;
-import moe.tristan.easyfxml.spring.application.FxUiManager;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
 import moe.lyrebird.model.notifications.Notification;
 import moe.lyrebird.model.notifications.NotificationService;
 import moe.lyrebird.model.settings.Setting;
 import moe.lyrebird.model.settings.SettingsService;
 import moe.lyrebird.model.twitter.TwitterStreamingService;
 import moe.lyrebird.view.screens.Screen;
-
-import javafx.application.Platform;
-import javafx.scene.Scene;
-import javafx.stage.Stage;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
+import moe.tristan.easyfxml.EasyFxml;
+import moe.tristan.easyfxml.api.FxmlNode;
+import moe.tristan.easyfxml.model.beanmanagement.StageManager;
+import moe.tristan.easyfxml.spring.application.FxUiManager;
 
 /**
  * The {@link LyrebirdUiManager} is responsible for bootstrapping the GUI of the application correctly.
@@ -121,6 +121,8 @@ public class LyrebirdUiManager extends FxUiManager {
         mainStage.setOnCloseRequest(e -> handleMainStageClosure(mainStage));
         mainStage.setMinHeight(environment.getRequiredProperty("mainStage.minHeight", Integer.class));
         mainStage.setMinWidth(environment.getRequiredProperty("mainStage.minWidth", Integer.class));
+        mainStage.setWidth(600.0);
+        mainStage.setHeight(500.0);
         stageManager.registerSingle(Screen.ROOT_VIEW, mainStage);
     }
 

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/FxComponent.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/FxComponent.java
@@ -30,6 +30,7 @@ import moe.lyrebird.view.components.directmessages.DirectMessagesController;
 import moe.lyrebird.view.components.mentions.MentionsController;
 import moe.lyrebird.view.components.notifications.NotificationsController;
 import moe.lyrebird.view.components.timeline.TimelineController;
+import moe.lyrebird.view.components.tweet.TweetContentPaneController;
 import moe.lyrebird.view.components.tweet.TweetInteractionPaneController;
 import moe.lyrebird.view.components.tweet.TweetPaneController;
 import moe.lyrebird.view.components.usertimeline.UserTimelineController;
@@ -54,6 +55,7 @@ public enum FxComponent implements FxmlNode {
     DIRECT_MESSAGE_PANE("directmessages/DMPane.fxml", DMPaneController.class),
 
     TWEET("tweet/TweetPane.fxml", TweetPaneController.class),
+    TWEET_CONTENT_PANE("tweet/TweetContentPane.fxml", TweetContentPaneController.class),
     TWEET_INTERACTION_BOX("tweet/TweetInteractionPane.fxml", TweetInteractionPaneController.class),
 
     CREDIT("credits/CreditPane.fxml", CreditController.class),

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetContentPane.fxml
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetContentPane.fxml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.text.Text?>
+<?import javafx.scene.text.TextFlow?>
+
+<AnchorPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="0.0" minWidth="0.0" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1" fx:controller="moe.lyrebird.view.components.tweet.TweetContentPaneController">
+   <children>
+      <TextFlow fx:id="tweetContent" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+         <children>
+            <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Example of a super long piece of text that needs to be wrapped. https://gitlab.com/gitlab-org/gitlab-runner/issues/82https://gitlab.com/gitlab-org/gitlab-runner/issues/82https://gitlab.com/gitlab-org/gitlab-runner/issues/82https://gitlab.com/gitlab-org/gitlab-runner/issues/82https://gitlab.com/gitlab-org/gitlab-runner/issues/82https://gitlab.com/gitlab-org/gitlab-runner/issues/82" />
+         </children></TextFlow>
+   </children>
+</AnchorPane>

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetContentPane.fxml
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetContentPane.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.text.Text?>
 <?import javafx.scene.text.TextFlow?>
 
-<AnchorPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="0.0" minWidth="0.0" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1" fx:controller="moe.lyrebird.view.components.tweet.TweetContentPaneController">
+<AnchorPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="moe.lyrebird.view.components.tweet.TweetContentPaneController">
    <children>
       <TextFlow fx:id="tweetContent" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
          <children>

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetContentPane.fxml
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetContentPane.fxml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.text.TextFlow?>
 
-<AnchorPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="moe.lyrebird.view.components.tweet.TweetContentPaneController">
-   <children>
-      <TextFlow fx:id="tweetContent" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
-   </children>
-</AnchorPane>
+<BorderPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="moe.lyrebird.view.components.tweet.TweetContentPaneController">
+   <center>
+      <TextFlow fx:id="tweetContent" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="10.0" minWidth="10.0" BorderPane.alignment="CENTER" />
+   </center>
+</BorderPane>

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetContentPane.fxml
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetContentPane.fxml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.text.Text?>
 <?import javafx.scene.text.TextFlow?>
 
 <AnchorPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="moe.lyrebird.view.components.tweet.TweetContentPaneController">
    <children>
-      <TextFlow fx:id="tweetContent" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-         <children>
-            <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Example of a super long piece of text that needs to be wrapped. https://gitlab.com/gitlab-org/gitlab-runner/issues/82https://gitlab.com/gitlab-org/gitlab-runner/issues/82https://gitlab.com/gitlab-org/gitlab-runner/issues/82https://gitlab.com/gitlab-org/gitlab-runner/issues/82https://gitlab.com/gitlab-org/gitlab-runner/issues/82https://gitlab.com/gitlab-org/gitlab-runner/issues/82" />
-         </children></TextFlow>
+      <TextFlow fx:id="tweetContent" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
    </children>
 </AnchorPane>

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetContentPaneController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetContentPaneController.java
@@ -1,0 +1,58 @@
+package moe.lyrebird.view.components.tweet;
+
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+import moe.tristan.easyfxml.api.FxmlController;
+import moe.lyrebird.view.util.HyperlinkUtils;
+import twitter4a.Status;
+import twitter4a.URLEntity;
+
+import javafx.beans.property.Property;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.fxml.FXML;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+
+import java.util.Arrays;
+
+@Component
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+public class TweetContentPaneController implements FxmlController {
+
+    @FXML
+    private TextFlow tweetContent;
+
+    private final Property<Status> statusProp = new SimpleObjectProperty<>();
+
+    @Override
+    public void initialize() {
+        if (statusProp.getValue() != null) {
+            statusReady();
+        }
+        statusProp.addListener((observable, oldValue, newValue) -> statusReady());
+    }
+
+
+    public void setStatusProp(final Status statusProp) {
+        this.statusProp.setValue(statusProp);
+    }
+
+    private void statusReady() {
+        tweetContent.getChildren().clear();
+        final String expanded = HyperlinkUtils.transformUrls(
+                statusProp.getValue().getText(),
+                this::expandedUrl
+        );
+
+        tweetContent.getChildren().add(new Text(expanded));
+    }
+
+    private String expandedUrl(final String shortUrl) {
+        return Arrays.stream(statusProp.getValue().getURLEntities())
+                     .filter(entity -> entity.getURL().equals(shortUrl))
+                     .map(URLEntity::getExpandedURL)
+                     .findAny()
+                     .orElse(shortUrl);
+    }
+}

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetContentPaneController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetContentPaneController.java
@@ -1,26 +1,28 @@
 package moe.lyrebird.view.components.tweet;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
-import moe.tristan.easyfxml.api.FxmlController;
-import moe.tristan.easyfxml.model.awt.integrations.BrowserSupport;
-import moe.lyrebird.view.util.ClickableHyperlink;
-import moe.lyrebird.view.util.HyperlinkUtils;
-import twitter4a.Status;
-import twitter4a.URLEntity;
 
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
+import moe.lyrebird.view.util.ClickableHyperlink;
+import moe.lyrebird.view.util.HyperlinkUtils;
+import moe.tristan.easyfxml.api.FxmlController;
+import moe.tristan.easyfxml.model.awt.integrations.BrowserSupport;
+import twitter4a.Status;
+import twitter4a.URLEntity;
 
 @Component
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
@@ -44,6 +46,7 @@ public class TweetContentPaneController implements FxmlController {
             statusReady();
         }
         statusProp.addListener((observable, oldValue, newValue) -> statusReady());
+        VBox.setVgrow(tweetContent, Priority.ALWAYS);
     }
 
 

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetContentPaneController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetContentPaneController.java
@@ -14,10 +14,15 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
-import moe.lyrebird.view.util.TwitterUrlEntitiesBuilder;
+import moe.lyrebird.view.util.TwitterContentTokenizer;
 import moe.tristan.easyfxml.api.FxmlController;
 import twitter4a.Status;
 
+/**
+ * This controller and its associated view represent and display the textual content of a Tweet as rich text.
+ *
+ * @see TwitterContentTokenizer
+ */
 @Component
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class TweetContentPaneController implements FxmlController {
@@ -25,13 +30,13 @@ public class TweetContentPaneController implements FxmlController {
     @FXML
     private TextFlow tweetContent;
 
-    private final TwitterUrlEntitiesBuilder twitterUrlEntitiesBuilder;
+    private final TwitterContentTokenizer twitterContentTokenizer;
 
     private final Property<Status> statusProp = new SimpleObjectProperty<>();
 
     @Autowired
-    public TweetContentPaneController(TwitterUrlEntitiesBuilder twitterUrlEntitiesBuilder) {
-        this.twitterUrlEntitiesBuilder = twitterUrlEntitiesBuilder;
+    public TweetContentPaneController(TwitterContentTokenizer twitterContentTokenizer) {
+        this.twitterContentTokenizer = twitterContentTokenizer;
     }
 
     @Override
@@ -48,8 +53,12 @@ public class TweetContentPaneController implements FxmlController {
         this.statusProp.setValue(status);
     }
 
+    /**
+     * This method tokenizes the newly loaded tweet via {@link TwitterContentTokenizer#asTextFlowTokens(Status)} and
+     * puts that result inside the embedding {@link TextFlow}.
+     */
     private void statusReady() {
-        final List<Text> textFlowElements = twitterUrlEntitiesBuilder.asTextFlowTokens(statusProp.getValue());
+        final List<Text> textFlowElements = twitterContentTokenizer.asTextFlowTokens(statusProp.getValue());
         tweetContent.getChildren().setAll(textFlowElements);
     }
 

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPane.fxml
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPane.fxml
@@ -22,7 +22,6 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
-<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Pane?>
@@ -57,7 +56,7 @@
             </HBox>
          </children>
       </HBox>
-      <HBox spacing="5.0" VBox.vgrow="ALWAYS">
+      <HBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="5.0" VBox.vgrow="ALWAYS">
          <children>
             <Pane fx:id="authorProfilePicturePane" focusTraversable="true" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="48.0" minWidth="48.0" prefHeight="48.0" prefWidth="48.0" HBox.hgrow="NEVER">
                <children>
@@ -72,7 +71,7 @@
                   <Insets top="2.5" />
                </HBox.margin>
             </Pane>
-            <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="5.0">
+            <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="5.0" HBox.hgrow="ALWAYS">
                <children>
                   <BorderPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mouseTransparent="true" prefWidth="50000.0">
                      <right>
@@ -91,7 +90,7 @@
                         </HBox>
                      </left>
                   </BorderPane>
-                  <AnchorPane fx:id="content" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="150.0" />
+                  <BorderPane fx:id="content" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" VBox.vgrow="ALWAYS" />
                   <HBox fx:id="mediaBox" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="20.0" minWidth="138.0" spacing="5.0" VBox.vgrow="ALWAYS" />
                   <BorderPane fx:id="interactionBox" />
                </children>

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPane.fxml
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPane.fxml
@@ -30,7 +30,7 @@
 <?import javafx.scene.shape.Circle?>
 <?import javafx.scene.text.Font?>
 
-<VBox alignment="CENTER_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="200.0" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1" fx:controller="moe.lyrebird.view.components.tweet.TweetPaneController">
+<VBox alignment="CENTER_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="200.0" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="moe.lyrebird.view.components.tweet.TweetPaneController">
    <children>
       <HBox fx:id="retweetHbox" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="5.0">
          <children>
@@ -91,7 +91,7 @@
                         </HBox>
                      </left>
                   </BorderPane>
-                  <AnchorPane fx:id="content" />
+                  <AnchorPane fx:id="content" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="150.0" />
                   <HBox fx:id="mediaBox" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="20.0" minWidth="138.0" spacing="5.0" VBox.vgrow="ALWAYS" />
                   <BorderPane fx:id="interactionBox" />
                </children>

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPane.fxml
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPane.fxml
@@ -71,7 +71,7 @@
                   <Insets top="2.5" />
                </HBox.margin>
             </Pane>
-            <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="5.0" HBox.hgrow="ALWAYS">
+            <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" spacing="10.0" HBox.hgrow="ALWAYS">
                <children>
                   <BorderPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mouseTransparent="true" prefWidth="50000.0">
                      <right>
@@ -90,7 +90,7 @@
                         </HBox>
                      </left>
                   </BorderPane>
-                  <BorderPane fx:id="content" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" VBox.vgrow="ALWAYS" />
+                  <VBox fx:id="tweetContent" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" VBox.vgrow="ALWAYS" />
                   <HBox fx:id="mediaBox" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="20.0" minWidth="138.0" spacing="5.0" VBox.vgrow="ALWAYS" />
                   <BorderPane fx:id="interactionBox" />
                </children>

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPane.fxml
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPane.fxml
@@ -29,9 +29,9 @@
 <?import javafx.scene.shape.Circle?>
 <?import javafx.scene.text.Font?>
 
-<VBox alignment="CENTER_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="200.0" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="moe.lyrebird.view.components.tweet.TweetPaneController">
+<VBox alignment="CENTER_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" prefWidth="200.0" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="moe.lyrebird.view.components.tweet.TweetPaneController">
    <children>
-      <HBox fx:id="retweetHbox" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="5.0">
+      <HBox fx:id="retweetHbox" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" spacing="5.0">
          <children>
             <HBox alignment="BOTTOM_RIGHT" prefWidth="48.0">
                <children>
@@ -56,7 +56,7 @@
             </HBox>
          </children>
       </HBox>
-      <HBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="5.0" VBox.vgrow="ALWAYS">
+      <HBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" spacing="5.0" VBox.vgrow="ALWAYS">
          <children>
             <Pane fx:id="authorProfilePicturePane" focusTraversable="true" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="48.0" minWidth="48.0" prefHeight="48.0" prefWidth="48.0" HBox.hgrow="NEVER">
                <children>

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPane.fxml
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPane.fxml
@@ -71,7 +71,7 @@
                   <Insets top="2.5" />
                </HBox.margin>
             </Pane>
-            <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" spacing="10.0" HBox.hgrow="ALWAYS">
+            <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" spacing="5.0" HBox.hgrow="ALWAYS">
                <children>
                   <BorderPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mouseTransparent="true" prefWidth="50000.0">
                      <right>

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPane.fxml
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPane.fxml
@@ -22,15 +22,15 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.shape.Circle?>
 <?import javafx.scene.text.Font?>
-<?import javafx.scene.text.TextFlow?>
 
-<VBox alignment="CENTER_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="200.0" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="moe.lyrebird.view.components.tweet.TweetPaneController">
+<VBox alignment="CENTER_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="200.0" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1" fx:controller="moe.lyrebird.view.components.tweet.TweetPaneController">
    <children>
       <HBox fx:id="retweetHbox" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="5.0">
          <children>
@@ -91,9 +91,9 @@
                         </HBox>
                      </left>
                   </BorderPane>
-                  <TextFlow fx:id="content" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" />
+                  <AnchorPane fx:id="content" />
                   <HBox fx:id="mediaBox" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="20.0" minWidth="138.0" spacing="5.0" VBox.vgrow="ALWAYS" />
-                  <BorderPane fx:id="interactionBox"/>
+                  <BorderPane fx:id="interactionBox" />
                </children>
             </VBox>
          </children>

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPaneController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPaneController.java
@@ -40,6 +40,8 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
 import moe.lyrebird.model.io.AsyncIO;
 import moe.lyrebird.model.twitter.user.UserDetailsService;
 import moe.lyrebird.view.components.FxComponent;
@@ -82,7 +84,7 @@ public class TweetPaneController implements ComponentCellFxmlController<Status> 
     private Pane authorProfilePicturePane;
 
     @FXML
-    private BorderPane content;
+    private VBox tweetContent;
 
     @FXML
     private HBox mediaBox;
@@ -199,7 +201,7 @@ public class TweetPaneController implements ComponentCellFxmlController<Status> 
      * @param status The status whose content we have to format
      */
     private void loadTextIntoTextFlow(final Status status) {
-        content.getChildren().clear();
+        tweetContent.getChildren().clear();
 
         final FxmlLoadResult<Pane, TweetContentPaneController> result = easyFxml.loadNode(
                 FxComponent.TWEET_CONTENT_PANE,
@@ -209,8 +211,9 @@ public class TweetPaneController implements ComponentCellFxmlController<Status> 
 
         result.afterControllerLoaded(tcpc -> tcpc.setStatusProp(status))
               .getNode()
+              .peek(pane -> VBox.setVgrow(pane, Priority.ALWAYS))
               .recover(ExceptionHandler::fromThrowable)
-              .andThen(content::setCenter);
+              .andThen(tweetContent.getChildren()::add);
     }
 
     /**

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPaneController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/tweet/TweetPaneController.java
@@ -18,24 +18,15 @@
 
 package moe.lyrebird.view.components.tweet;
 
+import static moe.lyrebird.view.assets.ImageResources.GENERAL_USER_AVATAR_DARK;
+import static moe.lyrebird.view.components.FxComponent.TWEET_INTERACTION_BOX;
+import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE;
+
+import java.util.List;
+
+import org.ocpsoft.prettytime.PrettyTime;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
-import moe.tristan.easyfxml.EasyFxml;
-import moe.tristan.easyfxml.model.awt.integrations.BrowserSupport;
-import moe.tristan.easyfxml.model.components.listview.ComponentCellFxmlController;
-import moe.tristan.easyfxml.model.exception.ExceptionHandler;
-import moe.tristan.easyfxml.model.fxml.FxmlLoadResult;
-import moe.tristan.easyfxml.util.Nodes;
-import moe.lyrebird.model.io.AsyncIO;
-import moe.lyrebird.model.twitter.user.UserDetailsService;
-import moe.lyrebird.view.components.FxComponent;
-import moe.lyrebird.view.components.cells.TweetListCell;
-import moe.lyrebird.view.screens.media.MediaEmbeddingService;
-import moe.lyrebird.view.screens.newtweet.NewTweetController;
-import moe.lyrebird.view.util.ClickableHyperlink;
-import moe.lyrebird.view.util.Clipping;
-import org.ocpsoft.prettytime.PrettyTime;
-import twitter4a.Status;
 
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
@@ -46,16 +37,22 @@ import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
-
-import java.util.List;
-
-import static moe.lyrebird.view.assets.ImageResources.GENERAL_USER_AVATAR_DARK;
-import static moe.lyrebird.view.components.FxComponent.TWEET_INTERACTION_BOX;
-import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE;
+import moe.lyrebird.model.io.AsyncIO;
+import moe.lyrebird.model.twitter.user.UserDetailsService;
+import moe.lyrebird.view.components.FxComponent;
+import moe.lyrebird.view.components.cells.TweetListCell;
+import moe.lyrebird.view.screens.media.MediaEmbeddingService;
+import moe.lyrebird.view.screens.newtweet.NewTweetController;
+import moe.lyrebird.view.util.Clipping;
+import moe.tristan.easyfxml.EasyFxml;
+import moe.tristan.easyfxml.model.components.listview.ComponentCellFxmlController;
+import moe.tristan.easyfxml.model.exception.ExceptionHandler;
+import moe.tristan.easyfxml.model.fxml.FxmlLoadResult;
+import moe.tristan.easyfxml.util.Nodes;
+import twitter4a.Status;
 
 /**
  * Displays a single tweet ({@link Status} in Twitter4J).
@@ -85,7 +82,7 @@ public class TweetPaneController implements ComponentCellFxmlController<Status> 
     private Pane authorProfilePicturePane;
 
     @FXML
-    private AnchorPane content;
+    private BorderPane content;
 
     @FXML
     private HBox mediaBox;
@@ -102,7 +99,6 @@ public class TweetPaneController implements ComponentCellFxmlController<Status> 
     @FXML
     private BorderPane interactionBox;
 
-    private final BrowserSupport browserSupport;
     private final AsyncIO asyncIO;
     private final MediaEmbeddingService mediaEmbeddingService;
     private final UserDetailsService userDetailsService;
@@ -113,13 +109,11 @@ public class TweetPaneController implements ComponentCellFxmlController<Status> 
     private final BooleanProperty embeddedProperty = new SimpleBooleanProperty(false);
 
     public TweetPaneController(
-            final BrowserSupport browserSupport,
             final AsyncIO asyncIO,
             final MediaEmbeddingService mediaEmbeddingService,
             final UserDetailsService userDetailsService,
             final EasyFxml easyFxml
     ) {
-        this.browserSupport = browserSupport;
         this.asyncIO = asyncIO;
         this.mediaEmbeddingService = mediaEmbeddingService;
         this.userDetailsService = userDetailsService;
@@ -216,7 +210,7 @@ public class TweetPaneController implements ComponentCellFxmlController<Status> 
         result.afterControllerLoaded(tcpc -> tcpc.setStatusProp(status))
               .getNode()
               .recover(ExceptionHandler::fromThrowable)
-              .andThen(content.getChildren()::add);
+              .andThen(content::setCenter);
     }
 
     /**
@@ -229,15 +223,6 @@ public class TweetPaneController implements ComponentCellFxmlController<Status> 
         mediaBox.setManaged(!embeddingNodes.isEmpty());
         mediaBox.setVisible(!embeddingNodes.isEmpty());
         mediaBox.getChildren().setAll(embeddingNodes);
-    }
-
-    /**
-     * @param url The URL itself
-     *
-     * @return a clickable link targeting the given URL
-     */
-    private ClickableHyperlink buildHyperlink(final String url) {
-        return new ClickableHyperlink(url, browserSupport::openUrl);
     }
 
 }

--- a/lyrebird/src/main/java/moe/lyrebird/view/screens/root/RootView.fxml
+++ b/lyrebird/src/main/java/moe/lyrebird/view/screens/root/RootView.fxml
@@ -25,7 +25,8 @@
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
-<BorderPane fx:id="contentPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="100.0" minWidth="500.0" prefHeight="500.0" prefWidth="600.0" styleClass="noFocus" stylesheets="@/style/lyrebird.css" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="moe.lyrebird.view.screens.root.RootScreenController">
+
+<BorderPane fx:id="contentPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="100.0" minWidth="0.0" styleClass="noFocus" stylesheets="@/style/lyrebird.css" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="moe.lyrebird.view.screens.root.RootScreenController">
    <center>
       <AnchorPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minWidth="0.0" BorderPane.alignment="CENTER">
          <children>

--- a/lyrebird/src/main/java/moe/lyrebird/view/util/ClickableHyperlink.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/util/ClickableHyperlink.java
@@ -18,18 +18,16 @@
 
 package moe.lyrebird.view.util;
 
-import javafx.geometry.Insets;
-import javafx.scene.control.Hyperlink;
-
 import java.util.function.Consumer;
 
-public final class ClickableHyperlink extends Hyperlink {
+import javafx.scene.text.Text;
+
+public final class ClickableHyperlink extends Text {
 
     public <T> ClickableHyperlink(final T element, final Consumer<T> onClicked) {
-        super();
-        setText(String.valueOf(element));
-        setOnAction(e -> onClicked.accept(element));
-        this.setPadding(Insets.EMPTY);
+        super(String.valueOf(element));
+        setOnMouseClicked(e -> onClicked.accept(element));
+        getStyleClass().setAll("clickable-hyperlink");
     }
 
 }

--- a/lyrebird/src/main/java/moe/lyrebird/view/util/ClickableHyperlink.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/util/ClickableHyperlink.java
@@ -30,4 +30,10 @@ public final class ClickableHyperlink extends Text {
         getStyleClass().setAll("clickable-hyperlink");
     }
 
+    public <T> ClickableHyperlink(final T element, final Runnable onClicked) {
+        super(String.valueOf(element));
+        setOnMouseClicked(e -> onClicked.run());
+        getStyleClass().setAll("clickable-hyperlink");
+    }
+
 }

--- a/lyrebird/src/main/java/moe/lyrebird/view/util/HyperlinkUtils.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/util/HyperlinkUtils.java
@@ -44,7 +44,7 @@ public final class HyperlinkUtils {
      *
      * @return The resulting string
      */
-    private static String transformUrls(final String input, final Function<String, String> replacer) {
+    public static String transformUrls(final String input, final Function<String, String> replacer) {
         return URL_PATTERN.matcher(input).replaceAll(match -> replacer.apply(match.group()));
     }
 

--- a/lyrebird/src/main/java/moe/lyrebird/view/util/HyperlinkUtils.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/util/HyperlinkUtils.java
@@ -70,4 +70,8 @@ public final class HyperlinkUtils {
         return transformUrls(input, url -> "");
     }
 
+    public static boolean isUrl(final String input) {
+        return URL_PATTERN.matcher(input).matches();
+    }
+
 }

--- a/lyrebird/src/main/java/moe/lyrebird/view/util/TwitterUrlEntitiesBuilder.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/util/TwitterUrlEntitiesBuilder.java
@@ -1,0 +1,152 @@
+package moe.lyrebird.view.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javafx.scene.text.Text;
+import moe.tristan.easyfxml.model.awt.integrations.BrowserSupport;
+import twitter4a.Status;
+import twitter4a.URLEntity;
+
+@Component
+public class TwitterUrlEntitiesBuilder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TwitterUrlEntitiesBuilder.class);
+
+    private static final int MAX_TOKEN_CACHE = 1000;
+
+    private final BrowserSupport browserSupport;
+
+    private final Map<Status, List<Token>> tokenizations = new LinkedHashMap<>() {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<Status, List<Token>> eldest) {
+            return size() > MAX_TOKEN_CACHE;
+        }
+    };
+
+    @Autowired
+    public TwitterUrlEntitiesBuilder(BrowserSupport browserSupport) {
+        this.browserSupport = browserSupport;
+    }
+
+    public List<Text> asTextFlowTokens(final Status status) {
+        List<Token> tokenizationResult = tokenizations.computeIfAbsent(status, this::tokenizeTweetContent);
+        return tokenizationResult.stream().map(Token::asTextElement).collect(Collectors.toList());
+    }
+
+    private List<Token> tokenizeTweetContent(final Status status) {
+        final String input = status.getText();
+        final URLEntity[] entities = status.getURLEntities();
+
+        if (entities.length == 0) {
+            return processNonUrlEntities(input, entities);
+        }
+
+        LOGGER.debug("Tokenizing tweet : {} [{} URL entities]", status.getId(), entities.length);
+
+        final List<Token> nodes = new ArrayList<>(entities.length * 2);
+
+        final List<URLEntity> sortedEntities = Arrays.stream(entities)
+                                                     .sorted(Comparator.comparingInt(URLEntity::getStart))
+                                                     .collect(Collectors.toList());
+
+        int cursorLeft = 0;
+        int cursorRight = 0;
+        for (final URLEntity entity : sortedEntities) {
+            cursorRight = entity.getStart();
+            if (cursorRight > cursorLeft) {
+                nodes.add(new Token(input.substring(cursorLeft, cursorRight)));
+            }
+            cursorLeft = cursorRight;
+            cursorRight = entity.getEnd();
+            nodes.add(linkOfEntity(entity));
+        }
+
+        if (cursorRight < input.length() - 1) {
+            nodes.addAll(processNonUrlEntities(input.substring(cursorRight), entities));
+        }
+
+        LOGGER.debug("Tokenized tweet as {}", tokenizationResult(nodes));
+
+        return nodes;
+    }
+
+    private Token linkOfEntity(final URLEntity urlEntity) {
+        return new Token(
+                urlEntity.getDisplayURL(),
+                TokenType.URL,
+                () -> browserSupport.openUrl(urlEntity.getExpandedURL())
+        );
+    }
+
+    private List<Token> processNonUrlEntities(final String endOfTweet, final URLEntity[] processedEntities) {
+        LOGGER.debug("Processing post-entity : {}", endOfTweet);
+
+        String fixedEnd = endOfTweet;
+        for (URLEntity processedEntity : processedEntities) {
+            fixedEnd = fixedEnd.replaceAll(processedEntity.getURL(), "");
+        }
+
+        List<Token> postEntitiesNodes = HyperlinkUtils.findAllUrls(fixedEnd).stream().map(
+                url -> new Token(
+                        url,
+                        TokenType.URL,
+                        () -> browserSupport.openUrl(url)
+                )
+        ).collect(Collectors.toList());
+        final Token postText = new Token(HyperlinkUtils.stripAllUrls(fixedEnd));
+        postEntitiesNodes.add(0, postText);
+        return postEntitiesNodes;
+    }
+
+    private List<String> tokenizationResult(final List<Token> nodes) {
+        return nodes.stream().map(Token::getTextValue).collect(Collectors.toList());
+    }
+
+    private static final class Token {
+
+        private final String textValue;
+        private final TokenType tokenType;
+        private final Runnable onClick;
+
+        private Token(String textValue, TokenType tokenType, Runnable onClick) {
+            this.textValue = textValue;
+            this.tokenType = tokenType;
+            this.onClick = onClick;
+        }
+
+        private Token(String textValue) {
+            this(textValue, TokenType.TEXT, null);
+        }
+
+        public String getTextValue() {
+            return textValue;
+        }
+
+        public Text asTextElement() {
+            switch (tokenType) {
+                case TEXT:
+                    return new Text(textValue);
+                case URL:
+                    return new ClickableHyperlink(textValue, onClick);
+            }
+            throw new UnsupportedOperationException("Tried to FXify undefined token type! [" + tokenType + "]");
+        }
+
+    }
+
+    private enum TokenType {
+        TEXT, URL
+    }
+
+}

--- a/lyrebird/src/main/resources/style/lyrebird.css
+++ b/lyrebird/src/main/resources/style/lyrebird.css
@@ -56,7 +56,7 @@
     -fx-faint-focus-color: transparent;
 }
 
-.list-view .list-cell:focused {
+.list-view .list-cell:filled:selected {
     -fx-background-color: -fx-background;
 }
 
@@ -64,7 +64,7 @@
     -fx-background-color: #ebebeb;
 }
 
-.list-view .list-cell:focused .hoverableButton:hover {
+.list-view .list-cell:selected .hoverableButton:hover {
     -fx-background-color: #cdd8e6;
 }
 

--- a/lyrebird/src/main/resources/style/lyrebird.css
+++ b/lyrebird/src/main/resources/style/lyrebird.css
@@ -79,3 +79,18 @@
 .hyperlink {
     -fx-text-fill: #29618b !important;
 }
+
+.clickable-hyperlink {
+    -fx-fill: rgb(55, 122, 224);
+    -fx-padding: 0;
+}
+
+.clickable-hyperlink:hover {
+    -fx-fill: rgb(61, 139, 255);
+    -fx-underline: true;
+}
+
+.clickable-hyperlink:pressed {
+    -fx-fill: rgb(40, 92, 168);
+    -fx-underline: true;
+}


### PR DESCRIPTION
# Clickable URLs in their original place in tweet content
### Fixes #98 

#### Summary
This feature required a proper String tokenizer which was quite the hassle to build. It's not perfect but a good beginning which will be iterated upon when implementing clickable mentions and hashtags.

#### Potential issues
Some weird edge cases are a bit broken.
Examples include 
```
<text...>
<externalUrl><emoji>
<twitterImageLink>
``` 
without spaces because Twitter does not return line feeds properly in all cases it seems. 
Example here : https://twitter.com/Nextclouders/status/1028303139110363136

#### Checks:
- [x] Documented code
- [x] Based on `develop` branch
