### PR TITLE
Make hashtags clickable in Tweets

### DIFF
--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/SimpleTextTokensCollector.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/SimpleTextTokensCollector.java
@@ -45,7 +45,14 @@ public final class SimpleTextTokensCollector {
     }
 
     private static Token asToken(final String text, final int begin, final int end) {
-        return new Token(text, begin, end);
+        return new Token(
+                text,
+                begin,
+                end,
+                Token.TokenType.SIMPLE_TEXT,
+                () -> {
+                }
+        );
     }
 
 }

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/SimpleTextTokensCollector.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/SimpleTextTokensCollector.java
@@ -45,14 +45,7 @@ public final class SimpleTextTokensCollector {
     }
 
     private static Token asToken(final String text, final int begin, final int end) {
-        return new Token(
-                text,
-                begin,
-                end,
-                Token.TokenType.SIMPLE_TEXT,
-                () -> {
-                }
-        );
+        return new Token(text, begin, end);
     }
 
 }

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/SimpleTextTokensCollector.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/SimpleTextTokensCollector.java
@@ -47,7 +47,6 @@ public final class SimpleTextTokensCollector {
     private static Token asToken(final String text, final int begin, final int end) {
         return new Token(
                 text,
-                text,
                 begin,
                 end,
                 Token.TokenType.SIMPLE_TEXT,

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/Token.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/Token.java
@@ -5,28 +5,37 @@ import javafx.scene.text.Text;
 import moe.lyrebird.view.viewmodel.javafx.ClickableText;
 
 /**
- * This class represents a String-convertible token that optionally triggers an action on click.
+ * This class represents a String-convertible token that can either represent some {@link TokenType#SIMPLE_TEXT} or
+ * a {@link TokenType#CLICKABLE} element.
  */
 public final class Token {
 
     private final String textRepresentation;
     private final int begin;
     private final int end;
+    private final TokenType tokenType;
     private final Runnable onClick;
 
-    public Token(final String textRepresentation, final int begin, final int end, final Runnable onClick) {
+    public Token(
+            final String textRepresentation,
+            final int begin,
+            final int end,
+            final TokenType tokenType,
+            final Runnable onClick
+    ) {
         this.textRepresentation = textRepresentation;
         this.begin = begin;
         this.end = end;
+        this.tokenType = tokenType;
         this.onClick = onClick;
     }
 
-    public Token(final String textRepresentation, final int begin, final int end) {
-        this(textRepresentation, begin, end, () -> {});
-    }
-
     public Text asTextElement() {
-        return new ClickableText(textRepresentation, onClick);
+        if (TokenType.SIMPLE_TEXT.equals(tokenType)) {
+            return new Text(textRepresentation);
+        } else {
+            return new ClickableText(textRepresentation, onClick);
+        }
     }
 
     public String getTextRepresentation() {
@@ -39,6 +48,14 @@ public final class Token {
 
     public int getEnd() {
         return end;
+    }
+
+    /**
+     * Simple enum flag for whether a given {@link Token} is actually plain text or a URL.
+     */
+    public enum TokenType {
+        SIMPLE_TEXT,
+        CLICKABLE
     }
 
 }

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/Token.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/Token.java
@@ -5,37 +5,28 @@ import javafx.scene.text.Text;
 import moe.lyrebird.view.viewmodel.javafx.ClickableText;
 
 /**
- * This class represents a String-convertible token that can either represent some {@link TokenType#SIMPLE_TEXT} or
- * a {@link TokenType#CLICKABLE} element.
+ * This class represents a String-convertible token that optionally triggers an action on click.
  */
 public final class Token {
 
     private final String textRepresentation;
     private final int begin;
     private final int end;
-    private final TokenType tokenType;
     private final Runnable onClick;
 
-    public Token(
-            final String textRepresentation,
-            final int begin,
-            final int end,
-            final TokenType tokenType,
-            final Runnable onClick
-    ) {
+    public Token(final String textRepresentation, final int begin, final int end, final Runnable onClick) {
         this.textRepresentation = textRepresentation;
         this.begin = begin;
         this.end = end;
-        this.tokenType = tokenType;
         this.onClick = onClick;
     }
 
+    public Token(final String textRepresentation, final int begin, final int end) {
+        this(textRepresentation, begin, end, () -> {});
+    }
+
     public Text asTextElement() {
-        if (TokenType.SIMPLE_TEXT.equals(tokenType)) {
-            return new Text(textRepresentation);
-        } else {
-            return new ClickableText(textRepresentation, onClick);
-        }
+        return new ClickableText(textRepresentation, onClick);
     }
 
     public String getTextRepresentation() {
@@ -48,14 +39,6 @@ public final class Token {
 
     public int getEnd() {
         return end;
-    }
-
-    /**
-     * Simple enum flag for whether a given {@link Token} is actually plain text or a URL.
-     */
-    public enum TokenType {
-        SIMPLE_TEXT,
-        CLICKABLE
     }
 
 }

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/Token.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/Token.java
@@ -42,4 +42,3 @@ public final class Token {
     }
 
 }
-

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/Token.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/Token.java
@@ -10,23 +10,20 @@ import moe.lyrebird.view.viewmodel.javafx.ClickableText;
  */
 public final class Token {
 
-    private final String originalStringValue;
-    private final String replacedStringValue;
+    private final String textRepresentation;
     private final int begin;
     private final int end;
     private final TokenType tokenType;
     private final Runnable onClick;
 
     public Token(
-            final String originalStringValue,
-            final String replacedStringValue,
+            final String textRepresentation,
             final int begin,
             final int end,
             final TokenType tokenType,
             final Runnable onClick
     ) {
-        this.originalStringValue = originalStringValue;
-        this.replacedStringValue = replacedStringValue;
+        this.textRepresentation = textRepresentation;
         this.begin = begin;
         this.end = end;
         this.tokenType = tokenType;
@@ -35,14 +32,14 @@ public final class Token {
 
     public Text asTextElement() {
         if (TokenType.SIMPLE_TEXT.equals(tokenType)) {
-            return new Text(replacedStringValue);
+            return new Text(textRepresentation);
         } else {
-            return new ClickableText(replacedStringValue, onClick);
+            return new ClickableText(textRepresentation, onClick);
         }
     }
 
-    public String getReplacedStringValue() {
-        return replacedStringValue;
+    public String getTextRepresentation() {
+        return textRepresentation;
     }
 
     public int getBegin() {

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/TweetContentTokenizer.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/TweetContentTokenizer.java
@@ -106,7 +106,7 @@ public class TweetContentTokenizer {
      * @return The string-convertible list of the tokens given as parameter.
      */
     private static List<String> tokenizationStringValue(final List<Token> tokens) {
-        return tokens.stream().map(Token::getReplacedStringValue).collect(Collectors.toList());
+        return tokens.stream().map(Token::getTextRepresentation).collect(Collectors.toList());
     }
 
 }

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/HashtagTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/HashtagTokensExtractor.java
@@ -1,0 +1,39 @@
+package moe.lyrebird.view.viewmodel.tokenization.extractors;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import moe.lyrebird.view.viewmodel.tokenization.Token;
+import moe.lyrebird.view.viewmodel.tokenization.TokensExtractor;
+import moe.tristan.easyfxml.model.awt.integrations.BrowserSupport;
+
+import twitter4a.Status;
+
+@Component
+public class HashtagTokensExtractor implements TokensExtractor {
+
+    private static final String HASHTAG_SEARCH_BASE_URL = "https://twitter.com/hashtag/";
+
+    private final BrowserSupport browserSupport;
+
+    @Autowired
+    public HashtagTokensExtractor(final BrowserSupport browserSupport) {
+        this.browserSupport = browserSupport;
+    }
+
+    @Override
+    public List<Token> extractTokens(final Status status) {
+        return Arrays.stream(status.getHashtagEntities()).map(hashtag -> new Token(
+                "#" + hashtag.getText(),
+                hashtag.getStart(),
+                hashtag.getEnd(),
+                Token.TokenType.CLICKABLE,
+                () -> browserSupport.openUrl(HASHTAG_SEARCH_BASE_URL + hashtag.getText())
+        )).collect(Collectors.toList());
+    }
+
+}

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/HashtagTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/HashtagTokensExtractor.java
@@ -31,7 +31,6 @@ public class HashtagTokensExtractor implements TokensExtractor {
                 "#" + hashtag.getText(),
                 hashtag.getStart(),
                 hashtag.getEnd(),
-                Token.TokenType.CLICKABLE,
                 () -> browserSupport.openUrl(HASHTAG_SEARCH_BASE_URL + hashtag.getText())
         )).collect(Collectors.toList());
     }

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/HashtagTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/HashtagTokensExtractor.java
@@ -31,6 +31,7 @@ public class HashtagTokensExtractor implements TokensExtractor {
                 "#" + hashtag.getText(),
                 hashtag.getStart(),
                 hashtag.getEnd(),
+                Token.TokenType.CLICKABLE,
                 () -> browserSupport.openUrl(HASHTAG_SEARCH_BASE_URL + hashtag.getText())
         )).collect(Collectors.toList());
     }

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/ManagedUrlsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/ManagedUrlsTokensExtractor.java
@@ -53,7 +53,6 @@ public class ManagedUrlsTokensExtractor implements TokensExtractor {
                 urlEntity.getDisplayURL(),
                 urlEntity.getStart(),
                 urlEntity.getEnd(),
-                Token.TokenType.CLICKABLE,
                 () -> browserSupport.openUrl(urlEntity.getExpandedURL())
         );
     }

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/ManagedUrlsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/ManagedUrlsTokensExtractor.java
@@ -50,7 +50,6 @@ public class ManagedUrlsTokensExtractor implements TokensExtractor {
     private Token linkOfEntity(final URLEntity urlEntity) {
         LOGGER.debug("Tokenizing URLEntity {}", urlEntity);
         return new Token(
-                urlEntity.getURL(),
                 urlEntity.getDisplayURL(),
                 urlEntity.getStart(),
                 urlEntity.getEnd(),

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/ManagedUrlsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/ManagedUrlsTokensExtractor.java
@@ -1,4 +1,4 @@
-package moe.lyrebird.view.viewmodel.tokenization.tokenizers;
+package moe.lyrebird.view.viewmodel.tokenization.extractors;
 
 import java.util.Arrays;
 import java.util.List;

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/ManagedUrlsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/ManagedUrlsTokensExtractor.java
@@ -53,6 +53,7 @@ public class ManagedUrlsTokensExtractor implements TokensExtractor {
                 urlEntity.getDisplayURL(),
                 urlEntity.getStart(),
                 urlEntity.getEnd(),
+                Token.TokenType.CLICKABLE,
                 () -> browserSupport.openUrl(urlEntity.getExpandedURL())
         );
     }

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/MentionsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/MentionsTokensExtractor.java
@@ -29,7 +29,6 @@ public class MentionsTokensExtractor implements TokensExtractor {
                 "@" + mention.getText(),
                 mention.getStart(),
                 mention.getEnd(),
-                Token.TokenType.CLICKABLE,
                 () -> userDetailsService.openUserDetails(mention.getId())
         )).collect(Collectors.toList());
     }

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/MentionsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/MentionsTokensExtractor.java
@@ -26,7 +26,6 @@ public class MentionsTokensExtractor implements TokensExtractor {
     @Override
     public List<Token> extractTokens(final Status status) {
         return Arrays.stream(status.getUserMentionEntities()).map(mention -> new Token(
-                mention.getText(),
                 "@" + mention.getText(),
                 mention.getStart(),
                 mention.getEnd(),

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/MentionsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/MentionsTokensExtractor.java
@@ -1,4 +1,4 @@
-package moe.lyrebird.view.viewmodel.tokenization.tokenizers;
+package moe.lyrebird.view.viewmodel.tokenization.extractors;
 
 import java.util.Arrays;
 import java.util.List;

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/MentionsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/MentionsTokensExtractor.java
@@ -29,6 +29,7 @@ public class MentionsTokensExtractor implements TokensExtractor {
                 "@" + mention.getText(),
                 mention.getStart(),
                 mention.getEnd(),
+                Token.TokenType.CLICKABLE,
                 () -> userDetailsService.openUserDetails(mention.getId())
         )).collect(Collectors.toList());
     }

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/UnmanagedUrlsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/UnmanagedUrlsTokensExtractor.java
@@ -47,6 +47,7 @@ public class UnmanagedUrlsTokensExtractor implements TokensExtractor {
                         urlWithPos._1,
                         urlWithPos._2,
                         urlWithPos._3,
+                        Token.TokenType.CLICKABLE,
                         () -> browserSupport.openUrl(urlWithPos._1)
                 )
         ).collect(Collectors.toList());

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/UnmanagedUrlsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/UnmanagedUrlsTokensExtractor.java
@@ -45,7 +45,6 @@ public class UnmanagedUrlsTokensExtractor implements TokensExtractor {
         return URLMatcher.findAllUrlsWithPosition(unamanagedText).stream().map(
                 urlWithPos -> new Token(
                         urlWithPos._1,
-                        urlWithPos._1,
                         urlWithPos._2,
                         urlWithPos._3,
                         Token.TokenType.CLICKABLE,

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/UnmanagedUrlsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/UnmanagedUrlsTokensExtractor.java
@@ -1,4 +1,4 @@
-package moe.lyrebird.view.viewmodel.tokenization.tokenizers;
+package moe.lyrebird.view.viewmodel.tokenization.extractors;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/UnmanagedUrlsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/UnmanagedUrlsTokensExtractor.java
@@ -47,7 +47,6 @@ public class UnmanagedUrlsTokensExtractor implements TokensExtractor {
                         urlWithPos._1,
                         urlWithPos._2,
                         urlWithPos._3,
-                        Token.TokenType.CLICKABLE,
                         () -> browserSupport.openUrl(urlWithPos._1)
                 )
         ).collect(Collectors.toList());


### PR DESCRIPTION
# Make hashtags clickable in Tweets in timeline views 
(or other controls using the default single Tweet control)

### Fixes #106 

#### Summary
Add a hashtag token extractor to the tokenization process to make hashtags clickable in the base representation of Tweets.

#### Potential issues
Not much tbh

#### Checks:
- [x] Documented code
- [x] Based on `develop` branch
