### PR TITLE
Auto refresh observable values in lieu of streaming

### DIFF
--- a/lyrebird/src/main/java/moe/lyrebird/model/sessions/SessionManager.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/sessions/SessionManager.java
@@ -18,26 +18,28 @@
 
 package moe.lyrebird.model.sessions;
 
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.context.ApplicationContext;
-import io.vavr.CheckedFunction1;
-import io.vavr.control.Try;
-import moe.lyrebird.model.twitter.twitter4j.TwitterHandler;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import twitter4a.Twitter;
-import twitter4a.User;
-import twitter4a.auth.AccessToken;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.ApplicationContext;
 
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import moe.lyrebird.model.twitter.twitter4j.TwitterHandler;
+
+import io.vavr.CheckedFunction1;
+import io.vavr.control.Try;
+import twitter4a.Twitter;
+import twitter4a.User;
+import twitter4a.auth.AccessToken;
 
 /**
  * The session manager is responsible for persisting the sessions in database and providing handles to them should
@@ -101,7 +103,7 @@ public class SessionManager {
                   .map(Property::getValue)
                   .map(Session::getTwitterHandler)
                   .map(TwitterHandler::getTwitter)
-                  .andThenTry(session -> LOG.debug(
+                  .andThenTry(session -> LOG.trace(
                           "Preparing request for user : {}",
                           session.getScreenName()
                   ));

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/DirectMessages.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/DirectMessages.java
@@ -79,7 +79,7 @@ public class DirectMessages implements RateLimited {
 
     @Override
     public int maxRequestsPer15Minutes() {
-        return 180;
+        return 15;
     }
 
     private void addDirectMessages(final List<DirectMessageEvent> loadedMessages) {

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/DirectMessages.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/DirectMessages.java
@@ -18,26 +18,29 @@
 
 package moe.lyrebird.model.twitter.observables;
 
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.stereotype.Component;
-import moe.lyrebird.model.sessions.SessionManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import twitter4a.DirectMessageEvent;
-import twitter4a.User;
-
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-import javafx.collections.ObservableMap;
-
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.ObservableMap;
+
+import moe.lyrebird.model.sessions.SessionManager;
+import moe.lyrebird.model.twitter.refresh.RateLimited;
+
+import twitter4a.DirectMessageEvent;
+import twitter4a.User;
+
 @Component
-public class DirectMessages {
+public class DirectMessages implements RateLimited {
 
     private static final Logger LOG = LoggerFactory.getLogger(DirectMessages.class);
 
@@ -58,6 +61,7 @@ public class DirectMessages {
         return messageEvents;
     }
 
+    @Override
     public void refresh() {
         if (!sessionManager.isLoggedInProperty().getValue()) {
             LOG.debug("Logged out, not refreshing direct messages.");
@@ -71,6 +75,11 @@ public class DirectMessages {
                           .onSuccess(this::addDirectMessages)
                           .onFailure(err -> LOG.error("Could not load direct messages successfully!", err));
         });
+    }
+
+    @Override
+    public int maxRequestsPer15Minutes() {
+        return 180;
     }
 
     private void addDirectMessages(final List<DirectMessageEvent> loadedMessages) {

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/DirectMessages.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/DirectMessages.java
@@ -51,10 +51,6 @@ public class DirectMessages implements RateLimited {
         this.sessionManager = sessionManager;
         LOG.debug("Initializing direct messages manager.");
         this.messageEvents = FXCollections.observableHashMap();
-        sessionManager.currentSessionProperty().addListener((o, prev, cur) -> refresh());
-        if (sessionManager.isLoggedInProperty().getValue()) {
-            refresh();
-        }
     }
 
     public ObservableMap<User, ObservableList<DirectMessageEvent>> directMessages() {

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/Mentions.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/Mentions.java
@@ -62,9 +62,8 @@ public class Mentions extends TwitterTimelineBaseModel implements RateLimited {
     }
 
     @Override
-    protected void addTweet(final Status newTweet) {
-        super.addTweet(newTweet);
-        final Notification mentionNotification = TwitterNotifications.fromMention(newTweet);
+    protected void onNewElementStreamed(final Status newElement) {
+        final Notification mentionNotification = TwitterNotifications.fromMention(newElement);
         notificationService.sendNotification(mentionNotification);
     }
 

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/Mentions.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/Mentions.java
@@ -18,32 +18,37 @@
 
 package moe.lyrebird.model.twitter.observables;
 
-import org.springframework.context.annotation.Lazy;
-import org.springframework.stereotype.Component;
-import moe.lyrebird.model.sessions.Session;
-import moe.lyrebird.model.sessions.SessionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+import moe.lyrebird.model.notifications.Notification;
+import moe.lyrebird.model.notifications.NotificationService;
+import moe.lyrebird.model.notifications.format.TwitterNotifications;
+import moe.lyrebird.model.sessions.SessionManager;
+import moe.lyrebird.model.twitter.refresh.RateLimited;
+
 import twitter4a.Paging;
 import twitter4a.ResponseList;
 import twitter4a.Status;
 import twitter4a.Twitter;
 import twitter4a.TwitterException;
-import twitter4a.UserMentionEntity;
-
-import java.util.Arrays;
 
 /**
  * This class exposes the current user's mentions in an observable way
  */
 @Lazy
 @Component
-public class Mentions extends TwitterTimelineBaseModel {
+public class Mentions extends TwitterTimelineBaseModel implements RateLimited {
 
     private static final Logger LOG = LoggerFactory.getLogger(Mentions.class);
 
-    public Mentions(final SessionManager sessionManager) {
+    private final NotificationService notificationService;
+
+    public Mentions(final SessionManager sessionManager, final NotificationService notificationService) {
         super(sessionManager);
+        this.notificationService = notificationService;
     }
 
     @Override
@@ -56,25 +61,21 @@ public class Mentions extends TwitterTimelineBaseModel {
         return twitter.getMentionsTimeline(paging);
     }
 
-    /**
-     * @param status the status to test against
-     *
-     * @return whether a given status is a mention to the current user
-     */
-    public boolean isMentionToCurrentUser(final Status status) {
-        final Session currentSession = sessionManager.currentSessionProperty().getValue();
-        if (currentSession == null) {
-            return false;
-        }
-        return Arrays.stream(status.getUserMentionEntities())
-                     .map(UserMentionEntity::getId)
-                     .map(String::valueOf)
-                     .anyMatch(currentSession.getUserId()::equals);
+    @Override
+    protected void addTweet(final Status newTweet) {
+        super.addTweet(newTweet);
+        final Notification mentionNotification = TwitterNotifications.fromMention(newTweet);
+        notificationService.sendNotification(mentionNotification);
     }
 
     @Override
     protected Logger getLocalLogger() {
         return LOG;
+    }
+
+    @Override
+    public int maxRequestsPer15Minutes() {
+        return 75;
     }
 
 }

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/Timeline.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/Timeline.java
@@ -80,7 +80,7 @@ public class Timeline extends TwitterTimelineBaseModel implements RateLimited {
 
     @Override
     public int maxRequestsPer15Minutes() {
-        return 900;
+        return 15;
     }
 
 }

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/Timeline.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/Timeline.java
@@ -18,28 +18,31 @@
 
 package moe.lyrebird.model.twitter.observables;
 
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
+
 import moe.lyrebird.model.sessions.SessionManager;
+import moe.lyrebird.model.twitter.refresh.RateLimited;
 import moe.lyrebird.model.twitter.services.interraction.TwitterInteractionService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import twitter4a.Paging;
 import twitter4a.Status;
 import twitter4a.Twitter;
 import twitter4a.TwitterException;
-
-import java.util.List;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * This class exposes the current user's timeline in an observable way
  */
 @Lazy
 @Component
-public class Timeline extends TwitterTimelineBaseModel {
+public class Timeline extends TwitterTimelineBaseModel implements RateLimited {
 
     private static final Logger LOG = LoggerFactory.getLogger(Timeline.class);
 
@@ -73,6 +76,11 @@ public class Timeline extends TwitterTimelineBaseModel {
     @Override
     protected Logger getLocalLogger() {
         return LOG;
+    }
+
+    @Override
+    public int maxRequestsPer15Minutes() {
+        return 900;
     }
 
 }

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/TwitterTimelineBaseModel.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/TwitterTimelineBaseModel.java
@@ -80,17 +80,14 @@ public abstract class TwitterTimelineBaseModel {
      * Asynchronously loads the last tweets available
      */
     public void refresh() {
-        if (!isFirstCall.get()) {
-            loadMoreTweets(loadedTweets.get(0).getId());
-        } else {
-            CompletableFuture.runAsync(() -> {
-                getLocalLogger().debug("Requesting last tweets in timeline.");
-                sessionManager.getCurrentTwitter()
-                              .mapTry(this::initialLoad)
-                              .onSuccess(this::addTweets)
-                              .andThen(() -> isFirstCall.set(false));
-            });
-        }
+        CompletableFuture.runAsync(() -> {
+            getLocalLogger().debug("Requesting last tweets in timeline.");
+            sessionManager.getCurrentTwitter()
+                          .mapTry(this::initialLoad)
+                          .onSuccess(this::addTweets)
+                          .onFailure(err -> getLocalLogger().error("Could not refresh!", err))
+                          .andThen(() -> isFirstCall.set(false));
+        });
     }
 
     /**

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/TwitterTimelineBaseModel.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/TwitterTimelineBaseModel.java
@@ -96,8 +96,8 @@ public abstract class TwitterTimelineBaseModel {
      * @param receivedTweets The tweets to add.
      */
     private void addTweets(final List<Status> receivedTweets) {
-        receivedTweets.forEach(this::addTweet);
-        getLocalLogger().debug("Loaded {} tweets successfully.", receivedTweets.size());
+        final int newTweets = receivedTweets.stream().map(this::addTweet).mapToInt(val -> val ? 1 : 0).sum();
+        getLocalLogger().debug("Loaded {} new tweets.", newTweets);
     }
 
     /**
@@ -105,14 +105,16 @@ public abstract class TwitterTimelineBaseModel {
      *
      * @param newTweet The tweet to add.
      */
-    private void addTweet(final Status newTweet) {
+    private boolean addTweet(final Status newTweet) {
         if (!this.loadedTweets.contains(newTweet)) {
             this.loadedTweets.add(newTweet);
             this.loadedTweets.sort(Comparator.comparingLong(Status::getId).reversed());
             if (!isFirstCall.get()) {
                 onNewElementStreamed(newTweet);
             }
+            return true;
         }
+        return false;
     }
 
     protected void onNewElementStreamed(final Status newElement) {

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/TwitterTimelineBaseModel.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/TwitterTimelineBaseModel.java
@@ -18,20 +18,22 @@
 
 package moe.lyrebird.model.twitter.observables;
 
-import moe.lyrebird.model.sessions.SessionManager;
-import org.slf4j.Logger;
-import twitter4a.Paging;
-import twitter4a.Status;
-import twitter4a.Twitter;
-import twitter4a.TwitterException;
-
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+
+import org.slf4j.Logger;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import moe.lyrebird.model.sessions.SessionManager;
+
+import twitter4a.Paging;
+import twitter4a.Status;
+import twitter4a.Twitter;
+import twitter4a.TwitterException;
 
 /**
  * This is the base class for reverse-chronologically sorted tweet lists (aka Timelines) backend model.
@@ -74,7 +76,7 @@ public abstract class TwitterTimelineBaseModel {
     /**
      * Asynchronously loads the last tweets available
      */
-    public void loadLastTweets() {
+    public void refresh() {
         CompletableFuture.runAsync(() -> {
             getLocalLogger().debug("Requesting last tweets in timeline.");
             sessionManager.getCurrentTwitter()
@@ -98,25 +100,11 @@ public abstract class TwitterTimelineBaseModel {
      *
      * @param newTweet The tweet to add.
      */
-    public void addTweet(final Status newTweet) {
+    protected void addTweet(final Status newTweet) {
         if (!this.loadedTweets.contains(newTweet)) {
             this.loadedTweets.add(newTweet);
             this.loadedTweets.sort(Comparator.comparingLong(Status::getId).reversed());
         }
-    }
-
-    /**
-     * Removes a given tweet from the list of currently loaded ones.
-     *
-     * @param removedId The id of the tweet to remove
-     *
-     * @see Status#getId()
-     */
-    public void removeTweet(final long removedId) {
-        this.loadedTweets.stream()
-                         .filter(status -> status.getId() == removedId)
-                         .findFirst()
-                         .ifPresent(this.loadedTweets::remove);
     }
 
     /**
@@ -127,7 +115,7 @@ public abstract class TwitterTimelineBaseModel {
     }
 
     /**
-     * Performs the initial load of tweets (i.e. {@link #loadLastTweets()}).
+     * Performs the initial load of tweets (i.e. {@link #refresh()}).
      *
      * @param twitter The twitter instance to use
      *

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/UserTimeline.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/observables/UserTimeline.java
@@ -18,24 +18,26 @@
 
 package moe.lyrebird.model.twitter.observables;
 
+import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
+
+import javafx.beans.property.Property;
+import javafx.beans.property.SimpleObjectProperty;
+
 import moe.lyrebird.model.sessions.SessionManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import twitter4a.Paging;
 import twitter4a.ResponseList;
 import twitter4a.Status;
 import twitter4a.Twitter;
 import twitter4a.TwitterException;
 import twitter4a.User;
-
-import javafx.beans.property.Property;
-import javafx.beans.property.SimpleObjectProperty;
-
-import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE;
 
 /**
  * This class exposes a user's self timeline in an observable way
@@ -54,7 +56,7 @@ public class UserTimeline extends TwitterTimelineBaseModel {
         super(sessionManager);
         this.targetUser.addListener((o, prev, cur) -> {
             this.clearLoadedTweets();
-            loadLastTweets();
+            refresh();
         });
     }
 

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/refresh/AutoRefreshService.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/refresh/AutoRefreshService.java
@@ -39,7 +39,7 @@ public class AutoRefreshService {
                 } catch (final Exception e) {
                     stopAutoRefreshing();
                 }
-            }, 0, secondsBetweenCalls, TimeUnit.SECONDS);
+            }, 5, secondsBetweenCalls, TimeUnit.SECONDS);
             LOGGER.debug("Scheduled autorefresh {} every {} seconds", rateLimitedCall, secondsBetweenCalls);
         });
     }

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/refresh/AutoRefreshService.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/refresh/AutoRefreshService.java
@@ -39,7 +39,7 @@ public class AutoRefreshService {
                 } catch (final Exception e) {
                     stopAutoRefreshing();
                 }
-            }, 5, secondsBetweenCalls, TimeUnit.SECONDS);
+            }, 2, secondsBetweenCalls, TimeUnit.SECONDS);
             LOGGER.debug("Scheduled autorefresh {} every {} seconds", rateLimitedCall, secondsBetweenCalls);
         });
     }

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/refresh/AutoRefreshService.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/refresh/AutoRefreshService.java
@@ -1,0 +1,57 @@
+package moe.lyrebird.model.twitter.refresh;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import moe.lyrebird.model.sessions.SessionManager;
+import moe.lyrebird.model.util.FXProperties;
+
+@Component
+public class AutoRefreshService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AutoRefreshService.class);
+
+    private static final ScheduledExecutorService REFRESHER = Executors.newSingleThreadScheduledExecutor();
+
+    private final List<RateLimited> rateLimitedCalls;
+
+    @Autowired
+    public AutoRefreshService(final SessionManager sessionManager, final List<RateLimited> rateLimitedCalls) {
+        this.rateLimitedCalls = rateLimitedCalls;
+        LOGGER.debug("Loaded the following autorefresh calls {}", rateLimitedCalls);
+        FXProperties.waitForBooleanProp(sessionManager.isLoggedInProperty(), this::startAutoRefreshing);
+    }
+
+    private void startAutoRefreshing() {
+        LOGGER.debug("Starting autorefreshes...");
+        rateLimitedCalls.forEach(rateLimitedCall -> {
+            final int secondsBetweenCalls = secondsBetweenCalls(rateLimitedCall);
+            REFRESHER.scheduleAtFixedRate(() -> {
+                try {
+                    rateLimitedCall.refresh();
+                } catch (final Exception e) {
+                    stopAutoRefreshing();
+                }
+            }, 0, secondsBetweenCalls, TimeUnit.SECONDS);
+            LOGGER.debug("Scheduled autorefresh {} every {} seconds", rateLimitedCall, secondsBetweenCalls);
+        });
+    }
+
+    private void stopAutoRefreshing() {
+        final List<Runnable> stopped = REFRESHER.shutdownNow();
+        LOGGER.debug("Stopped autorefreshing for all calls [{}] : {}", rateLimitedCalls, stopped);
+    }
+
+    private static int secondsBetweenCalls(final RateLimited rateLimited) {
+        final double secBetweenCalls = (15.0 * 60.0) / ((double) rateLimited.maxRequestsPer15Minutes() * 0.8);
+        return (int) Math.max(3, secBetweenCalls);
+    }
+
+}

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/refresh/RateLimited.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/refresh/RateLimited.java
@@ -1,0 +1,9 @@
+package moe.lyrebird.model.twitter.refresh;
+
+public interface RateLimited {
+
+    int maxRequestsPer15Minutes();
+
+    void refresh();
+
+}

--- a/lyrebird/src/main/java/moe/lyrebird/model/twitter/util/TwitterMediaExtensionFilter.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/twitter/util/TwitterMediaExtensionFilter.java
@@ -16,7 +16,7 @@
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package moe.lyrebird.model.twitter;
+package moe.lyrebird.model.twitter.util;
 
 import java.util.Arrays;
 import java.util.List;

--- a/lyrebird/src/main/java/moe/lyrebird/model/util/FXProperties.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/util/FXProperties.java
@@ -23,7 +23,11 @@ public final class FXProperties {
         if (prop.getValue() != null && prop.getValue()) {
             onReady.run();
         } else {
-            waitForProp(prop, val -> onReady.run());
+            prop.addListener((observable, oldValue, newValue) -> {
+                if (newValue) {
+                    onReady.run();
+                }
+            });
         }
     }
 

--- a/lyrebird/src/main/java/moe/lyrebird/model/util/FXProperties.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/util/FXProperties.java
@@ -1,0 +1,30 @@
+package moe.lyrebird.model.util;
+
+import java.util.function.Consumer;
+
+import javafx.beans.value.ObservableValue;
+
+public final class FXProperties {
+
+    private FXProperties() {
+    }
+
+    public static <T> void waitForProp(final ObservableValue<T> prop, final Consumer<T> onReady) {
+        if (prop.getValue() == null) {
+            prop.addListener((observable, oldValue, newValue) -> {
+                onReady.accept(newValue);
+            });
+        } else {
+            onReady.accept(prop.getValue());
+        }
+    }
+
+    public static void waitForBooleanProp(final ObservableValue<Boolean> prop, final Runnable onReady) {
+        if (prop.getValue() != null && prop.getValue()) {
+            onReady.run();
+        } else {
+            waitForProp(prop, val -> onReady.run());
+        }
+    }
+
+}

--- a/lyrebird/src/main/java/moe/lyrebird/view/LyrebirdUiManager.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/LyrebirdUiManager.java
@@ -18,23 +18,24 @@
 
 package moe.lyrebird.view;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
-import moe.tristan.easyfxml.EasyFxml;
-import moe.tristan.easyfxml.api.FxmlNode;
-import moe.tristan.easyfxml.model.beanmanagement.StageManager;
-import moe.tristan.easyfxml.spring.application.FxUiManager;
+
+import javafx.application.Platform;
+import javafx.stage.Stage;
+
 import moe.lyrebird.model.notifications.Notification;
 import moe.lyrebird.model.notifications.NotificationService;
 import moe.lyrebird.model.settings.Setting;
 import moe.lyrebird.model.settings.SettingsUtils;
 import moe.lyrebird.view.screens.Screen;
-
-import javafx.application.Platform;
-import javafx.stage.Stage;
-
-import java.util.concurrent.atomic.AtomicBoolean;
+import moe.tristan.easyfxml.EasyFxml;
+import moe.tristan.easyfxml.api.FxmlNode;
+import moe.tristan.easyfxml.model.beanmanagement.StageManager;
+import moe.tristan.easyfxml.spring.application.FxUiManager;
 
 /**
  * The {@link LyrebirdUiManager} is responsible for bootstrapping the GUI of the application correctly.

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/base/TimelineControllerBase.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/base/TimelineControllerBase.java
@@ -26,7 +26,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.ReadOnlyListWrapper;
 
-import moe.lyrebird.model.sessions.SessionManager;
 import moe.lyrebird.model.twitter.observables.TwitterTimelineBaseModel;
 import moe.lyrebird.view.components.cells.TweetListCell;
 import moe.lyrebird.view.components.mentions.MentionsController;
@@ -47,39 +46,28 @@ public abstract class TimelineControllerBase extends ComponentListViewFxmlContro
 
     private final TwitterTimelineBaseModel timelineBase;
     private final ListProperty<Status> tweetsProperty;
-    private final boolean shouldAutomaticallyFill;
 
     /**
      * This constructor is called by the implementing class rather than Spring because there is no way we will ever use
      * field injection in Lyrebird.
      *
      * @param timelineBase            The backing model-side controller taking care of requests and exposing tweets
-     * @param sessionManager          The session manager is used only for bootstrapping and does not leak outside of
-     *                                constructor
      * @param context                 The spring context that is passed onto {@link ComponentListViewFxmlController} for
      *                                constructor injection.
-     * @param shouldAutomaticallyFill Whether this controller should directly start fetching tweets on creation.
      */
     public TimelineControllerBase(
             final TwitterTimelineBaseModel timelineBase,
-            final SessionManager sessionManager,
-            final ConfigurableApplicationContext context,
-            final boolean shouldAutomaticallyFill
+            final ConfigurableApplicationContext context
     ) {
         super(context, TweetListCell.class);
         this.timelineBase = timelineBase;
         this.tweetsProperty = new ReadOnlyListWrapper<>(timelineBase.loadedTweets());
-        this.shouldAutomaticallyFill = shouldAutomaticallyFill;
-        sessionManager.currentSessionProperty().addListener(change -> timelineBase.refresh());
     }
 
     @Override
     public void initialize() {
         super.initialize();
         listView.itemsProperty().bind(new ReadOnlyListWrapper<>(timelineBase.loadedTweets()));
-        if (shouldAutomaticallyFill) {
-            timelineBase.refresh();
-        }
     }
 
     /**

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/base/TimelineControllerBase.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/base/TimelineControllerBase.java
@@ -70,7 +70,7 @@ public abstract class TimelineControllerBase extends ComponentListViewFxmlContro
         this.timelineBase = timelineBase;
         this.tweetsProperty = new ReadOnlyListWrapper<>(timelineBase.loadedTweets());
         this.shouldAutomaticallyFill = shouldAutomaticallyFill;
-        sessionManager.currentSessionProperty().addListener(change -> timelineBase.loadLastTweets());
+        sessionManager.currentSessionProperty().addListener(change -> timelineBase.refresh());
     }
 
     @Override
@@ -78,7 +78,7 @@ public abstract class TimelineControllerBase extends ComponentListViewFxmlContro
         super.initialize();
         listView.itemsProperty().bind(new ReadOnlyListWrapper<>(timelineBase.loadedTweets()));
         if (shouldAutomaticallyFill) {
-            timelineBase.loadLastTweets();
+            timelineBase.refresh();
         }
     }
 

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/mentions/MentionsController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/mentions/MentionsController.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.stereotype.Component;
 
-import moe.lyrebird.model.sessions.SessionManager;
 import moe.lyrebird.model.twitter.observables.Mentions;
 import moe.lyrebird.view.components.base.TimelineControllerBase;
 
@@ -37,12 +36,8 @@ public class MentionsController extends TimelineControllerBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(MentionsController.class);
 
-    public MentionsController(
-            final Mentions mentions,
-            final SessionManager sessionManager,
-            final ConfigurableApplicationContext context
-    ) {
-        super(mentions, sessionManager, context, true);
+    public MentionsController(final Mentions mentions, final ConfigurableApplicationContext context) {
+        super(mentions, context);
     }
 
     @Override

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/timeline/TimelineController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/timeline/TimelineController.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.stereotype.Component;
 
-import moe.lyrebird.model.sessions.SessionManager;
 import moe.lyrebird.model.twitter.observables.Timeline;
 import moe.lyrebird.view.components.base.TimelineControllerBase;
 
@@ -37,12 +36,8 @@ public class TimelineController extends TimelineControllerBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(TimelineController.class);
 
-    public TimelineController(
-            final Timeline timeline,
-            final SessionManager sessionManager,
-            final ConfigurableApplicationContext context
-    ) {
-        super(timeline, sessionManager, context, true);
+    public TimelineController(final Timeline timeline, final ConfigurableApplicationContext context) {
+        super(timeline, context);
     }
 
     @Override

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/usertimeline/UserTimelineController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/usertimeline/UserTimelineController.java
@@ -27,7 +27,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import moe.lyrebird.model.sessions.SessionManager;
 import moe.lyrebird.model.twitter.observables.UserTimeline;
 import moe.lyrebird.view.components.base.TimelineControllerBase;
 
@@ -46,13 +45,15 @@ public class UserTimelineController extends TimelineControllerBase {
     private final UserTimeline userTimeline;
 
     @Autowired
-    public UserTimelineController(
-            final UserTimeline userTimeline,
-            final SessionManager sessionManager,
-            final ConfigurableApplicationContext context
-    ) {
-        super(userTimeline, sessionManager, context, false);
+    public UserTimelineController(final UserTimeline userTimeline, final ConfigurableApplicationContext context) {
+        super(userTimeline, context);
         this.userTimeline = userTimeline;
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+        userTimeline.refresh();
     }
 
     /**

--- a/lyrebird/src/main/java/moe/lyrebird/view/screens/newtweet/NewTweetController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/screens/newtweet/NewTweetController.java
@@ -68,7 +68,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import moe.lyrebird.model.sessions.SessionManager;
-import moe.lyrebird.model.twitter.TwitterMediaExtensionFilter;
+import moe.lyrebird.model.twitter.util.TwitterMediaExtensionFilter;
 import moe.lyrebird.model.twitter.observables.Mentions;
 import moe.lyrebird.model.twitter.observables.Timeline;
 import moe.lyrebird.model.twitter.services.NewTweetService;

--- a/lyrebird/src/main/java/moe/lyrebird/view/screens/newtweet/NewTweetController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/screens/newtweet/NewTweetController.java
@@ -248,8 +248,8 @@ public class NewTweetController implements FxmlController, StageAware {
                            LOG.info("Tweeted status : {} [{}]", status.getId(), status.getText());
                            this.embeddingStage.getValue().hide();
                        }, Platform::runLater)
-                       .thenRunAsync(timeline::loadLastTweets)
-                       .thenRunAsync(mentions::loadLastTweets);
+                       .thenRunAsync(timeline::refresh)
+                       .thenRunAsync(mentions::refresh);
     }
 
     /**
@@ -263,8 +263,8 @@ public class NewTweetController implements FxmlController, StageAware {
                            LOG.info("Tweeted reply to {} : {} [{}]", inReplyToId, status.getId(), status.getText());
                            this.embeddingStage.getValue().hide();
                        }, Platform::runLater)
-                       .thenRunAsync(timeline::loadLastTweets)
-                       .thenRunAsync(mentions::loadLastTweets);
+                       .thenRunAsync(timeline::refresh)
+                       .thenRunAsync(mentions::refresh);
     }
 
     /**

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/TweetContentTokenizer.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/TweetContentTokenizer.java
@@ -81,7 +81,7 @@ public class TweetContentTokenizer {
      * @return The {@link Token}ized representation of the given {@link Status}.
      */
     private List<Token> tokenize(final Status status) {
-        LOGGER.debug("Tokenizing status {}", status.getId());
+        LOGGER.trace("Tokenizing status {}", status.getId());
         final List<Token> clickableTokens = tokensExtractors.stream()
                                                             .map(extractor -> extractor.extractTokens(status))
                                                             .flatMap(List::stream)
@@ -94,7 +94,7 @@ public class TweetContentTokenizer {
                                                .sorted(Comparator.comparingInt(Token::getBegin))
                                                .collect(Collectors.toList());
 
-        LOGGER.debug("Tokenized status {} as : {}", status.getId(), tokenizationStringValue(tokenization));
+        LOGGER.trace("Tokenized status {} as : {}", status.getId(), tokenizationStringValue(tokenization));
         return tokenization;
     }
 

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/ManagedUrlsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/ManagedUrlsTokensExtractor.java
@@ -48,7 +48,7 @@ public class ManagedUrlsTokensExtractor implements TokensExtractor {
      * @return A token that correctly this entity.
      */
     private Token linkOfEntity(final URLEntity urlEntity) {
-        LOGGER.debug("Tokenizing URLEntity {}", urlEntity);
+        LOGGER.trace("Tokenizing URLEntity {}", urlEntity);
         return new Token(
                 urlEntity.getDisplayURL(),
                 urlEntity.getStart(),


### PR DESCRIPTION
# Setup automatic refresh of user site data in lieu of streaming
### Fixes #111 

#### Summary
Where streaming API brought most value we replace it with some rate-limited auto-refresh.
It is although super not-perfect and will require a few more iterations to get right probably. It is currently very easy to rate-limit yourself unfortunately...

#### Potential issues
Rate-limiting due to heuristics being way too basic at the moment.

#### Checks:
- [x] Documented code
- [x] Based on `develop` branch
