### PR TITLE
Update workflow linux

### DIFF
--- a/lyrebird/src/main/java/moe/lyrebird/model/update/selfupdate/linux/PackageKitService.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/update/selfupdate/linux/PackageKitService.java
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.freedesktop.dbus.CallbackHandler;
 import org.freedesktop.dbus.DBusConnection;
 import org.freedesktop.dbus.DBusInterface;
+import org.freedesktop.dbus.DBusInterfaceName;
 import org.freedesktop.dbus.UInt32;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
@@ -33,17 +34,13 @@ public class PackageKitService {
     public void showNativeUnixPackageKitPrompt() {
         final DBusConnection conn = getDbusConnectionHolder();
         try {
-            final DBusInterface packageKit = conn.getRemoteObject(
+            final IPackageKit packageKit = conn.getRemoteObject(
                     "org.freedesktop.PackageKit",
-                    "/org/freedesktop/PackageKit"
+                    "/org/freedesktop/PackageKit",
+                    IPackageKit.class
             );
-            conn.callWithCallback(
-                    packageKit,
-                    "InstallPackageNames",
-                    new DBusCallbackHandler(),
-                    UInt32.MIN_VALUE,
-                    "lyrebird"
-            );
+            // FIXME: find the correct XID
+            packageKit.InstallPackageNames(new UInt32(0), new String[] {"lyrebird"}, "");
         } catch (DBusException e) {
             e.printStackTrace();
         }
@@ -64,4 +61,14 @@ public class PackageKitService {
 
     }
 
+}
+
+/* subset of the PackageKit Session DBus interface that's relevant to us
+ *
+ * https://blog.fpmurphy.com/2013/11/packagekit-d-bus-abstraction-layer.html
+ * https://techbase.kde.org/Development/Tutorials/PackageKit_Session_Interface
+ */
+@DBusInterfaceName("org.freedesktop.PackageKit.Modify")
+interface IPackageKit extends DBusInterface {
+    void InstallPackageNames(UInt32 xid, String[] packages, String interaction);
 }


### PR DESCRIPTION
# Title of PR
### Fixes #96

#### Summary
I just figured out how to use the DBus interface.

#### Potential issues
The xid parameter is for the X server display that the package manager should be on. 99.99% of the time it's 0, and it seems that Gnome Software, for instance, doesn't use it anyway[1].
The third parameter is for options, but again Gnome Software doesn't use it either[1] and I'm not sure what the options in the example script mean[2].

#### Checks:
- [ ] Documented code
- [x] Based on `develop` branch

[1] https://github.com/GNOME/gnome-software/blob/master/src/gs-dbus-helper.c#L400
[2] https://www.freedesktop.org/software/PackageKit/pk-faq.html#session-methods