### PR TITLE
Update EasyFXML version to get browser support from JavaFX instead of AWT

### DIFF
--- a/lyrebird/pom.xml
+++ b/lyrebird/pom.xml
@@ -168,7 +168,7 @@
         <dependency>
             <groupId>moe.tristan</groupId>
             <artifactId>easyfxml</artifactId>
-            <version>1.1.7</version>
+            <version>1.1.8</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.hamcrest</groupId>

--- a/lyrebird/src/main/java/moe/lyrebird/model/systemtray/LyrebirdTrayIcon.java
+++ b/lyrebird/src/main/java/moe/lyrebird/model/systemtray/LyrebirdTrayIcon.java
@@ -6,6 +6,7 @@ import java.awt.event.MouseListener;
 import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.slf4j.Logger;
@@ -58,9 +59,8 @@ public class LyrebirdTrayIcon implements SystemTrayIcon {
     }
 
     @Override
-    public MouseListener onMouseClickListener() {
-        //noop
-        return null;
+    public Optional<MouseListener> onMouseClickListener() {
+        return Optional.empty();
     }
 
     /**

--- a/lyrebird/src/main/java/moe/lyrebird/view/components/credits/CreditController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/components/credits/CreditController.java
@@ -22,10 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
-import moe.tristan.easyfxml.model.awt.integrations.BrowserSupport;
-import moe.tristan.easyfxml.model.components.listview.ComponentCellFxmlController;
-import moe.lyrebird.model.credits.objects.CreditedWork;
-import moe.lyrebird.view.screens.Screen;
 
 import javafx.application.Platform;
 import javafx.beans.property.Property;
@@ -33,6 +29,11 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.fxml.FXML;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
+
+import moe.lyrebird.model.credits.objects.CreditedWork;
+import moe.lyrebird.view.screens.Screen;
+import moe.tristan.easyfxml.model.components.listview.ComponentCellFxmlController;
+import moe.tristan.easyfxml.model.system.BrowserSupport;
 
 /**
  * This component is the one managing a single credit disclaimer unit in the credits list view.

--- a/lyrebird/src/main/java/moe/lyrebird/view/screens/credits/CreditsScreenController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/screens/credits/CreditsScreenController.java
@@ -41,8 +41,8 @@ import moe.lyrebird.model.twitter.user.UserDetailsService;
 import moe.lyrebird.view.components.cells.CreditsCell;
 import moe.lyrebird.view.components.credits.CreditController;
 import moe.lyrebird.view.viewmodel.javafx.Clipping;
-import moe.tristan.easyfxml.model.awt.integrations.BrowserSupport;
 import moe.tristan.easyfxml.model.components.listview.ComponentListViewFxmlController;
+import moe.tristan.easyfxml.model.system.BrowserSupport;
 import moe.tristan.easyfxml.util.Buttons;
 
 import twitter4j.User;

--- a/lyrebird/src/main/java/moe/lyrebird/view/screens/login/LoginScreenController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/screens/login/LoginScreenController.java
@@ -18,21 +18,16 @@
 
 package moe.lyrebird.view.screens.login;
 
+import java.net.URL;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
-import moe.tristan.easyfxml.api.FxmlController;
-import moe.tristan.easyfxml.model.awt.integrations.BrowserSupport;
-import moe.tristan.easyfxml.model.exception.ExceptionHandler;
-import moe.tristan.easyfxml.util.Buttons;
-import io.vavr.Tuple2;
-import moe.lyrebird.model.sessions.SessionManager;
-import moe.lyrebird.model.twitter.twitter4j.TwitterHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import twitter4j.auth.AccessToken;
-import twitter4j.auth.RequestToken;
 
 import javafx.fxml.FXML;
 import javafx.scene.Node;
@@ -43,9 +38,16 @@ import javafx.scene.control.TextField;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 
-import java.net.URL;
-import java.util.Optional;
-import java.util.stream.Stream;
+import moe.lyrebird.model.sessions.SessionManager;
+import moe.lyrebird.model.twitter.twitter4j.TwitterHandler;
+import moe.tristan.easyfxml.api.FxmlController;
+import moe.tristan.easyfxml.model.exception.ExceptionHandler;
+import moe.tristan.easyfxml.model.system.BrowserSupport;
+import moe.tristan.easyfxml.util.Buttons;
+
+import io.vavr.Tuple2;
+import twitter4j.auth.AccessToken;
+import twitter4j.auth.RequestToken;
 
 /**
  * This class is responsible for managing the login screen.

--- a/lyrebird/src/main/java/moe/lyrebird/view/screens/update/UpdateScreenController.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/screens/update/UpdateScreenController.java
@@ -31,7 +31,7 @@ import moe.lyrebird.api.model.LyrebirdVersion;
 import moe.lyrebird.model.update.UpdateService;
 import moe.lyrebird.view.screens.Screen;
 import moe.tristan.easyfxml.api.FxmlController;
-import moe.tristan.easyfxml.model.awt.integrations.BrowserSupport;
+import moe.tristan.easyfxml.model.system.BrowserSupport;
 
 /**
  * This controller is responsible for managing the {@link Screen#UPDATE_VIEW} screen.

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/HashtagTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/HashtagTokensExtractor.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 import moe.lyrebird.view.viewmodel.tokenization.Token;
 import moe.lyrebird.view.viewmodel.tokenization.TokensExtractor;
-import moe.tristan.easyfxml.model.awt.integrations.BrowserSupport;
+import moe.tristan.easyfxml.model.system.BrowserSupport;
 
 import twitter4j.Status;
 

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/ManagedUrlsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/ManagedUrlsTokensExtractor.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import moe.lyrebird.view.viewmodel.tokenization.Token;
 import moe.lyrebird.view.viewmodel.tokenization.TokensExtractor;
-import moe.tristan.easyfxml.model.awt.integrations.BrowserSupport;
+import moe.tristan.easyfxml.model.system.BrowserSupport;
 
 import twitter4j.Status;
 import twitter4j.URLEntity;

--- a/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/UnmanagedUrlsTokensExtractor.java
+++ b/lyrebird/src/main/java/moe/lyrebird/view/viewmodel/tokenization/extractors/UnmanagedUrlsTokensExtractor.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import moe.lyrebird.model.util.URLMatcher;
 import moe.lyrebird.view.viewmodel.tokenization.Token;
 import moe.lyrebird.view.viewmodel.tokenization.TokensExtractor;
-import moe.tristan.easyfxml.model.awt.integrations.BrowserSupport;
+import moe.tristan.easyfxml.model.system.BrowserSupport;
 
 import twitter4j.Status;
 import twitter4j.URLEntity;


### PR DESCRIPTION
# Update EasyFXML version to get browser support from JavaFX instead of AWT

#### Summary
Mostly an upstream update to EasyFXML to make sure that browser link opening is based off of the JavaFX HostServices class rather than the legacy Desktop AWT class, which is not reliable on many Linux distributions due to requiring Gnome shell utilities, but in a version outdated nowadays.

#### Potential issues
None really.

#### Checks:
- [x] Documented code
- [x] Based on `develop` branch
